### PR TITLE
Authetication - decode cookie

### DIFF
--- a/infrastructure/ktor/src/main/kotlin/ktor/Authentication.kt
+++ b/infrastructure/ktor/src/main/kotlin/ktor/Authentication.kt
@@ -32,7 +32,7 @@ fun Application.loginModule(config: Config) {
     install(Authentication) {
         jwt {
             authHeader {
-                it.request.cookies[AUTH_COOKIE]?.let { parseAuthorizationHeader(it) }
+                it.request.cookies[AUTH_COOKIE]?.let { parseAuthorizationHeader(decodeCookieValue(it, CookieEncoding.URI_ENCODING)) }
                     ?: it.request.parseAuthorizationHeader()
             }
             val authenticator = this@loginModule.get<Authenticator>() as JWTAuthenticatorImpl


### PR DESCRIPTION
the /login endpoint sends a cookie; this cookie uses the CookieEncoding.URI_ENCODING encoding by default.

before executing the parseAuthorizationHeader method you must decode the cookie, otherwise it will never be recognized as correct