### PR TITLE
Graphql kotlin

### DIFF
--- a/adapters/graphql/build.gradle.kts
+++ b/adapters/graphql/build.gradle.kts
@@ -4,6 +4,4 @@ dependencies {
 
     implementation("com.expediagroup", "graphql-kotlin-server", libs.versions.graphqlkotlin.get())
     implementation("com.graphql-java", "graphql-java-extended-scalars", libs.versions.graphqlScalars.get())
-
-    implementation(kotlin("reflect", libs.versions.kotlin.get()))
 }

--- a/adapters/graphql/src/main/kotlin/graphql/DataFatcher.kt
+++ b/adapters/graphql/src/main/kotlin/graphql/DataFatcher.kt
@@ -4,6 +4,7 @@ import com.expediagroup.graphql.generator.execution.FunctionDataFetcher
 import com.expediagroup.graphql.generator.execution.SimpleKotlinDataFetcherFactoryProvider
 import graphql.schema.DataFetcherFactory
 import graphql.schema.DataFetchingEnvironment
+import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 
@@ -19,10 +20,24 @@ class CustomDataFetcherFactory: SimpleKotlinDataFetcherFactoryProvider() {
     }
 }
 
+// map usecase class with map of original argument name - new name {usecase class - [old name * new name]}
+val paramMap = mutableMapOf<KClass<*>, MutableMap<String, String>>()
 class CustomFunctionDataFetcher(target: Any?, fn: KFunction<*>) : FunctionDataFetcher(target, fn) {
+    // get function class name (there's a better way to get the class??)
+    private val className = fn.toString().substringBeforeLast(".invoke").substringAfter(" ")
+    private val kClass = Class.forName(className).kotlin
+    // as the convertArgumentValue is an internal method we have to use reflections to get it
+    private val convertArgumentValue = Class.forName("com.expediagroup.graphql.generator.execution.ConvertArgumentValueKt")
+        .declaredMethods.find { it.name == "convertArgumentValue" }!!
+
+
     override fun mapParameterToValue(param: KParameter, environment: DataFetchingEnvironment): Pair<KParameter, Any?>? =
-        when (param.name) {
-            "authentication" -> param to environment.graphQlContext.get("userPrincipal")
+        when {
+            param.name == "authentication" -> param to environment.graphQlContext.get("userPrincipal")
+            paramMap[kClass]?.get(param.name) != null -> {
+                // call the convertArgumentValue function
+                param to convertArgumentValue(this, paramMap[kClass]!![param.name], param, environment.arguments)
+            }
             else -> super.mapParameterToValue(param, environment)
         }
 }

--- a/adapters/graphql/src/main/kotlin/graphql/Hooks.kt
+++ b/adapters/graphql/src/main/kotlin/graphql/Hooks.kt
@@ -4,11 +4,13 @@ import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
 import domain.entity.user.Email
 import domain.entity.user.NewPassword
 import domain.entity.user.Password
+import graphql.customScalars.EmailScalar
+import graphql.customScalars.NewPasswordScalar
+import graphql.customScalars.PasswordScalar
 import graphql.scalars.datetime.DateScalar
+import graphql.scalars.java.JavaPrimitives
 import graphql.schema.*
-import mutationNames
-import queryNames
-import java.util.*
+import java.time.LocalDate
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KType
@@ -66,10 +68,7 @@ class Hooks: SchemaGeneratorHooks {
         function: KFunction<*>,
         fieldDefinition: GraphQLFieldDefinition
     ): GraphQLFieldDefinition {
-        val newArguments = fieldDefinition.arguments.toMutableList()
-        newArguments.removeAt(0)
-        val newFieldDefinition = fieldDefinition.transform { it.replaceArguments(newArguments) }
-
+        val newFieldDefinition = reworkArguments(fieldDefinition)
         return super.didGenerateQueryField(kClass, function, newFieldDefinition)
     }
 
@@ -81,11 +80,15 @@ class Hooks: SchemaGeneratorHooks {
         function: KFunction<*>,
         fieldDefinition: GraphQLFieldDefinition
     ): GraphQLFieldDefinition {
+        val newFieldDefinition = reworkArguments(fieldDefinition)
+        return super.didGenerateMutationField(kClass, function, newFieldDefinition)
+    }
+
+    private fun reworkArguments(fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition {
         val newArguments = fieldDefinition.arguments.toMutableList()
         newArguments.removeAt(0)
-        val newFieldDefinition = fieldDefinition.transform { it.replaceArguments(newArguments) }
 
-        return super.didGenerateMutationField(kClass, function, newFieldDefinition)
+        return fieldDefinition.transform{ it.replaceArguments(newArguments) }
     }
 
     /**
@@ -96,8 +99,8 @@ class Hooks: SchemaGeneratorHooks {
             Email::class -> EmailScalar.INSTANCE
             Password::class -> PasswordScalar.INSTANCE
             NewPassword::class -> NewPasswordScalar.INSTANCE
-            Date::class -> DateScalar.INSTANCE
-            Long::class -> Scalars.GraphQLInt
+            LocalDate::class -> DateScalar.INSTANCE
+            Long::class -> JavaPrimitives.GraphQLLong
             else -> null
         }
     }

--- a/adapters/graphql/src/main/kotlin/graphql/KtorGraphqLSchema.kt
+++ b/adapters/graphql/src/main/kotlin/graphql/KtorGraphqLSchema.kt
@@ -1,10 +1,9 @@
+package graphql
+
 import com.expediagroup.graphql.generator.SchemaGeneratorConfig
 import com.expediagroup.graphql.generator.TopLevelObject
 import com.expediagroup.graphql.generator.toSchema
-import graphql.CustomDataFetcherFactory
-import graphql.CustomValueUnboxer
-import graphql.GraphQL
-import graphql.Hooks
+import graphql.customScalars.CustomValueUnboxer
 import graphql.schema.GraphQLSchema
 import usecases.usecase.Mutation
 import usecases.usecase.Query

--- a/adapters/graphql/src/main/kotlin/graphql/customScalars/ValueClassScalar.kt
+++ b/adapters/graphql/src/main/kotlin/graphql/customScalars/ValueClassScalar.kt
@@ -1,4 +1,4 @@
-package graphql
+package graphql.customScalars
 
 import com.expediagroup.graphql.generator.scalars.IDValueUnboxer
 import domain.entity.ValueClass
@@ -26,37 +26,37 @@ class CustomValueUnboxer : IDValueUnboxer() {
  * Scalars for value classes
  * I think there's a better way to handle value classes scalars...
  */
-object EmailScalar {
-        private val coercing: Coercing<Email, String?> = object : Coercing<Email, String?> {
-            override fun serialize(dataFetcherResult: Any): String {
-                return dataFetcherResult.toString()
-            }
+abstract class ValueClassCoercing<V : ValueClass<String>>(name: String) : Coercing<V, String?> {
+    final override fun serialize(dataFetcherResult: Any): String {
+        return dataFetcherResult.toString()
+    }
 
-            override fun parseValue(input: Any): Email {
-                if (input is String)
-                    return Email(input)
-                throw CoercingParseValueException()
-            }
-
-            override fun parseLiteral(input: Any): Email {
-                if (input is StringValue)
-                    return Email(input.value)
-                throw CoercingParseLiteralException()
-            }
-        }
-
-    var INSTANCE: GraphQLScalarType? = GraphQLScalarType.newScalar()
-        .name("Email")
-        .coercing(coercing)
+    val INSTANCE: GraphQLScalarType? = GraphQLScalarType.newScalar()
+        .name(name)
+        .coercing(this)
         .build()
 }
 
-object PasswordScalar {
-    private val coercing: Coercing<Password, String?> = object : Coercing<Password, String?> {
-        override fun serialize(dataFetcherResult: Any): String {
-            return dataFetcherResult.toString()
+object EmailScalar {
+    private val coercing: ValueClassCoercing<Email> = object : ValueClassCoercing<Email>("Email") {
+        override fun parseValue(input: Any): Email {
+            if (input is String)
+                return Email(input)
+            throw CoercingParseValueException()
         }
 
+        override fun parseLiteral(input: Any): Email {
+            if (input is StringValue)
+                return Email(input.value)
+            throw CoercingParseLiteralException()
+        }
+    }
+
+    val INSTANCE: GraphQLScalarType? = coercing.INSTANCE
+}
+
+object PasswordScalar {
+    private val coercing: ValueClassCoercing<Password> = object : ValueClassCoercing<Password>("Password") {
         override fun parseValue(input: Any): Password {
             if (input is String)
                 return Password(input)
@@ -70,18 +70,11 @@ object PasswordScalar {
         }
     }
 
-    var INSTANCE: GraphQLScalarType? = GraphQLScalarType.newScalar()
-        .name("Password")
-        .coercing(coercing)
-        .build()
+    val INSTANCE: GraphQLScalarType? = coercing.INSTANCE
 }
 
 object NewPasswordScalar {
-    private val coercing: Coercing<NewPassword, String?> = object : Coercing<NewPassword, String?> {
-        override fun serialize(dataFetcherResult: Any): String {
-            return dataFetcherResult.toString()
-        }
-
+    private val coercing: ValueClassCoercing<NewPassword> = object : ValueClassCoercing<NewPassword>("NewPassword") {
         override fun parseValue(input: Any): NewPassword {
             if (input is String)
                 return NewPassword(input)
@@ -95,8 +88,5 @@ object NewPasswordScalar {
         }
     }
 
-    var INSTANCE: GraphQLScalarType? = GraphQLScalarType.newScalar()
-        .name("NewPassword")
-        .coercing(coercing)
-        .build()
+    val INSTANCE: GraphQLScalarType? = coercing.INSTANCE
 }

--- a/domain/src/main/kotlin/domain/repository/Pagination.kt
+++ b/domain/src/main/kotlin/domain/repository/Pagination.kt
@@ -1,6 +1,6 @@
 package domain.repository
 
-import java.util.*
+import java.time.LocalDate
 
 data class Pagination(
     val itemsPerPage: Int,
@@ -22,8 +22,8 @@ enum class Order {
 }
 
 data class Period(
-    val from: Date,
-    val to: Date
+    val from: LocalDate,
+    val to: LocalDate
 )
 
 open class PaginationResult<T : Any>(

--- a/infrastructure/ktor/src/main/kotlin/ktor/plugins/graphql/GraphqlModule.kt
+++ b/infrastructure/ktor/src/main/kotlin/ktor/plugins/graphql/GraphqlModule.kt
@@ -1,8 +1,8 @@
 package ktor.plugins.graphql
 
-import buildSchema
 import com.expediagroup.graphql.generator.extensions.print
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import graphql.buildSchema
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*

--- a/infrastructure/ktor/src/main/kotlin/ktor/plugins/graphql/KtorGrapgQLServer.kt
+++ b/infrastructure/ktor/src/main/kotlin/ktor/plugins/graphql/KtorGrapgQLServer.kt
@@ -3,7 +3,7 @@ package ktor.plugins.graphql
 import com.expediagroup.graphql.server.execution.GraphQLRequestHandler
 import com.expediagroup.graphql.server.execution.GraphQLServer
 import com.fasterxml.jackson.databind.ObjectMapper
-import getGraphQLObject
+import graphql.getGraphQLObject
 import graphql.schema.GraphQLSchema
 import io.ktor.server.request.*
 

--- a/use-cases/src/main/kotlin/usecases/usecase/user/ChangeOwnPassword.kt
+++ b/use-cases/src/main/kotlin/usecases/usecase/user/ChangeOwnPassword.kt
@@ -21,9 +21,9 @@ class ChangeOwnPassword(
 ) : UsecaseA1<ChangeOwnPasswordModel, UserModel>(typeOf<ChangeOwnPasswordModel>(), typeOf<UserModel>(), logger) {
 
     override val authorities = emptyList<Authorities>()
-    override suspend fun executor(authentication: UserModel?, a0: ChangeOwnPasswordModel): UserModel {
+    override suspend fun executor(authentication: UserModel?, passwords: ChangeOwnPasswordModel): UserModel {
         val user = repository.findById(authentication!!.id) ?: throw AuthorizationException()
-        if (!passwordEncoder.matches(a0.current, user.password)) throw AuthorizationException()
-        return changePassword(authentication, ChangePasswordModel(authentication.id, a0.password))
+        if (!passwordEncoder.matches(passwords.current, user.password)) throw AuthorizationException()
+        return changePassword(authentication, ChangePasswordModel(authentication.id, passwords.password))
     }
 }

--- a/use-cases/src/main/kotlin/usecases/usecase/user/ChangePassword.kt
+++ b/use-cases/src/main/kotlin/usecases/usecase/user/ChangePassword.kt
@@ -20,9 +20,9 @@ class ChangePassword(
 ) : UsecaseA1<ChangePasswordModel, UserModel>(typeOf<ChangePasswordModel>(), typeOf<UserModel>(), logger) {
 
     override val authorities = emptyList<Authorities>()
-    override suspend fun executor(authentication: UserModel?, a0: ChangePasswordModel): UserModel {
-        if (authentication!!.id != a0.id && !authentication.authorities.contains(Authorities.USER)) throw AuthorizationException()
-        val user = repository.findById(a0.id) ?: throw UserNotFoundException()
-        return UserModel(repository.update(user.copy(password = passwordEncoder.encode(a0.password))))
+    override suspend fun executor(authentication: UserModel?, password: ChangePasswordModel): UserModel {
+        if (authentication!!.id != password.id && !authentication.authorities.contains(Authorities.USER)) throw AuthorizationException()
+        val user = repository.findById(password.id) ?: throw UserNotFoundException()
+        return UserModel(repository.update(user.copy(password = passwordEncoder.encode(password.password))))
     }
 }

--- a/use-cases/src/main/kotlin/usecases/usecase/user/CreateUser.kt
+++ b/use-cases/src/main/kotlin/usecases/usecase/user/CreateUser.kt
@@ -20,8 +20,8 @@ class CreateUser(
 ) : UsecaseA1<CreateUserModel, UserModel>(typeOf<CreateUserModel>(), typeOf<UserModel>(), logger) {
 
     override val authorities = listOf(Authorities.USER)
-    override suspend fun executor(authentication: UserModel?, a0: CreateUserModel): UserModel {
-        if (userExists(authentication, a0.email)) throw EmailAlreadyExistsException()
-        return UserModel(repository.create(a0.toUser(passwordEncoder)))
+    override suspend fun executor(authentication: UserModel?, user: CreateUserModel): UserModel {
+        if (userExists(authentication, user.email)) throw EmailAlreadyExistsException()
+        return UserModel(repository.create(user.toUser(passwordEncoder)))
     }
 }

--- a/use-cases/src/main/kotlin/usecases/usecase/user/DeleteUser.kt
+++ b/use-cases/src/main/kotlin/usecases/usecase/user/DeleteUser.kt
@@ -15,8 +15,8 @@ class DeleteUser(
 ) : UsecaseA1<Int, Boolean>(typeOf<Int>(), typeOf<Boolean>(), logger) {
 
     override val authorities = listOf(Authorities.USER)
-    override suspend fun executor(authentication: UserModel?, a0: Int): Boolean {
-        repository.delete(a0)
+    override suspend fun executor(authentication: UserModel?, id: Int): Boolean {
+        repository.delete(id)
         return true
     }
 }

--- a/use-cases/src/main/kotlin/usecases/usecase/user/GetUser.kt
+++ b/use-cases/src/main/kotlin/usecases/usecase/user/GetUser.kt
@@ -15,7 +15,7 @@ class GetUser(
 ) : UsecaseA1<Int, UserModel>(typeOf<Int>(), typeOf<UserModel>(), logger) {
 
     override val authorities = listOf(Authorities.USER)
-    override suspend fun executor(authentication: UserModel?, a0: Int): UserModel {
-        return repository.findById(a0)?.let { UserModel(it) }!!
+    override suspend fun executor(authentication: UserModel?, id: Int): UserModel {
+        return repository.findById(id)?.let { UserModel(it) }!!
     }
 }

--- a/use-cases/src/main/kotlin/usecases/usecase/user/ListUsers.kt
+++ b/use-cases/src/main/kotlin/usecases/usecase/user/ListUsers.kt
@@ -17,7 +17,7 @@ class ListUsers(
 ) : UsecaseA1<Pagination, UserPaginationResult>(typeOf<Pagination>(), typeOf<UserPaginationResult>(), logger) {
 
     override val authorities = listOf(Authorities.USER)
-    override suspend fun executor(authentication: UserModel?, a0: Pagination): UserPaginationResult {
-        return UserPaginationResult(repository.findAll(a0))
+    override suspend fun executor(authentication: UserModel?, pagination: Pagination): UserPaginationResult {
+        return UserPaginationResult(repository.findAll(pagination))
     }
 }

--- a/use-cases/src/main/kotlin/usecases/usecase/user/LoginUser.kt
+++ b/use-cases/src/main/kotlin/usecases/usecase/user/LoginUser.kt
@@ -22,9 +22,9 @@ class LoginUser(
 
     override val authenticated = false
     override val authorities = emptyList<Authorities>()
-    override suspend fun executor(authentication: UserModel?, a0: LoginUserModel): String {
-        val user = repository.findByEmail(a0.email)
-        if (user == null || user.locked || !passwordEncoder.matches(a0.password, user.password)) throw LoginException()
+    override suspend fun executor(authentication: UserModel?, login: LoginUserModel): String {
+        val user = repository.findByEmail(login.email)
+        if (user == null || user.locked || !passwordEncoder.matches(login.password, user.password)) throw LoginException()
         return "Bearer " + authenticator.generate(UserModel(user))
     }
 }

--- a/use-cases/src/main/kotlin/usecases/usecase/user/UpdateUser.kt
+++ b/use-cases/src/main/kotlin/usecases/usecase/user/UpdateUser.kt
@@ -19,9 +19,9 @@ class UpdateUser(
 ) : UsecaseA1<UpdateUserModel, UserModel>(typeOf<UpdateUserModel>(), typeOf<UserModel>(), logger) {
 
     override val authorities = listOf(Authorities.USER)
-    override suspend fun executor(authentication: UserModel?, a0: UpdateUserModel): UserModel {
-        val old = repository.findById(a0.id) ?: throw UserNotFoundException()
-        if (old.email != a0.email && userExists(authentication, a0.email)) throw EmailAlreadyExistsException()
-        return UserModel(repository.update(a0.toUser(old.password)))
+    override suspend fun executor(authentication: UserModel?, user: UpdateUserModel): UserModel {
+        val old = repository.findById(user.id) ?: throw UserNotFoundException()
+        if (old.email != user.email && userExists(authentication, user.email)) throw EmailAlreadyExistsException()
+        return UserModel(repository.update(user.toUser(old.password)))
     }
 }

--- a/use-cases/src/main/kotlin/usecases/usecase/user/UserExists.kt
+++ b/use-cases/src/main/kotlin/usecases/usecase/user/UserExists.kt
@@ -16,7 +16,7 @@ class UserExists(
 ) : UsecaseA1<Email, Boolean>(typeOf<Email>(), typeOf<Boolean>(), logger) {
 
     override val authorities = listOf(Authorities.USER)
-    override suspend fun executor(authentication: UserModel?, a0: Email): Boolean {
-        return repository.findByEmail(a0) != null
+    override suspend fun executor(authentication: UserModel?, email: Email): Boolean {
+        return repository.findByEmail(email) != null
     }
 }


### PR DESCRIPTION
@ESchouten I added argument renaming to graphql-kotlin although the way I did it is a little unusual

I worked with the Hook methods `didGenerateQueryField` and `didGenerateMutationField` to modify the schema and rename the arguments

Doing this broke the DataFetcher (the original implementation compares the name of the query argument with the name of the function parameter, if there is a match calls the `convertArgumentValue` for the conversion)... This method `convertArgumentValue ` is internal and not public, so I had to retrieve it with reflections

I honestly don't understand the purpose of the two methods `didGenerateQueryField` and `didGenerateMutationField`, because every change in the schema results in a break in the datafetcher